### PR TITLE
add paragraph on R and link to Dataverse installation guide.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ To use the Data Explorer as part of your Dataverse installation simply download 
 The config file [https://scholarsportal.github.io/Dataverse-Data-Explorer/dataExplorerLocal.json](https://scholarsportal.github.io/Dataverse-Data-Explorer/dataExplorerLocal.json) can be used for local installations assuming the Data Explorer application is placed in the Dataverse project directory {Dataverse Dir}/src/main/webapp/ddi_explore 
 
 
-See [http://guides.dataverse.org/en/4.8.6/installation/external-tools.html](http://guides.dataverse.org/en/4.8.6/installation/external-tools.html) for further information.
+See [http://guides.dataverse.org/en/4.8.6/installation/external-tools.html](http://guides.dataverse.org/en/4.8.6/installation/external-tools.html) for further information on external tools.
+
+Note that your Dataverse installation needs to be properly configured to produce .prep metadata, with all the required R components installed. Consult the [Dataverse Installation Guide](http://guides.dataverse.org/en/latest/installation/index.html) for details.
 
 ### Main Interface
 The main interface displays the first 10 variables from the data file. 


### PR DESCRIPTION
R installation/config page in Dataverse installation guide forthcoming.

context: Leonid found that Data Explorer requires that Dataverse's R server offer the "DescTools" package; he's working on docs for the Dataverse installation guide now.