### PR TITLE
fix bugs related to weights and groups

### DIFF
--- a/src/app/new.state/xml/xml.interface.ts
+++ b/src/app/new.state/xml/xml.interface.ts
@@ -13,7 +13,7 @@ interface Question {
   postQTxt?: string;
 }
 
-interface SummaryStatistic {
+export interface SummaryStatistic {
   '#text': string | number;
   '@_type': string;
   '@_wgtd'?: string;
@@ -175,6 +175,13 @@ export interface ddiJSONStructure {
   codeBook: CodeBook;
 }
 
+export interface UnmatchedWeightVariable {
+  variableID: string;
+  variableName: string;
+  /** The `@_wgt-var` value from the imported XML that had no match in the current dataset */
+  importedWgtVar: string;
+}
+
 export interface XmlState {
   dataset: ddiJSONStructure | null;
   header: {
@@ -188,6 +195,10 @@ export interface XmlState {
     language?: string;
     importedSuccess?: boolean;
     secureUploadUrl: string | null;
+    /** Variables whose imported weight reference could not be mapped to the current dataset.
+     * TODO: surface this list in the import result component so users know which variables
+     * lost their weight assignment and need to be reassigned manually. */
+    unmatchedImportedWeights?: UnmatchedWeightVariable[];
   } | null;
   error: {
     type: 'fetch' | 'upload' | 'chrome-error' | null;

--- a/src/app/new.state/xml/xml.reducer.ts
+++ b/src/app/new.state/xml/xml.reducer.ts
@@ -135,16 +135,19 @@ export const xmlReducer = createReducer(
         createNewVariables(variablesMatched, variables, variableTemplate);
       duplicateState.dataset.codeBook.dataDscr.var = updatedVariables;
       if (variableTemplate.groups) {
-        const importedVariableGroups =
-          importDdiData.codeBook.dataDscr.varGrp || [];
-        variableGroups = updateGroups(
-          Array.isArray(importedVariableGroups)
-            ? importedVariableGroups
-            : [importedVariableGroups],
-          variablesMatched,
-          Array.isArray(variableGroups) ? variableGroups : [],
-        );
-        duplicateState.dataset.codeBook.dataDscr.varGrp = variableGroups;
+        const rawImportedGroups = importDdiData.codeBook.dataDscr.varGrp;
+        if (rawImportedGroups) {
+          const importedVariableGroups = Array.isArray(rawImportedGroups)
+            ? rawImportedGroups
+            : [rawImportedGroups];
+          variableGroups = updateGroups(
+            importedVariableGroups,
+            variablesMatched,
+            Array.isArray(variableGroups) ? variableGroups : [],
+          );
+          duplicateState.dataset.codeBook.dataDscr.varGrp = variableGroups;
+        }
+        // If the imported XML has no varGrp, leave existing groups untouched.
       }
 
       if (duplicateState.info) {

--- a/src/app/new.state/xml/xml.reducer.ts
+++ b/src/app/new.state/xml/xml.reducer.ts
@@ -131,11 +131,9 @@ export const xmlReducer = createReducer(
         importedVariablesArray,
         variables,
       );
-      duplicateState.dataset.codeBook.dataDscr.var = createNewVariables(
-        variablesMatched,
-        variables,
-        variableTemplate,
-      );
+      const { variables: updatedVariables, unmatchedWeights } =
+        createNewVariables(variablesMatched, variables, variableTemplate);
+      duplicateState.dataset.codeBook.dataDscr.var = updatedVariables;
       if (variableTemplate.groups) {
         const importedVariableGroups =
           importDdiData.codeBook.dataDscr.varGrp || [];
@@ -151,10 +149,12 @@ export const xmlReducer = createReducer(
 
       if (duplicateState.info) {
         duplicateState.info.importedSuccess = true;
+        duplicateState.info.unmatchedImportedWeights = unmatchedWeights;
       } else {
         duplicateState.info = {
           secureUploadUrl: null,
           importedSuccess: true,
+          unmatchedImportedWeights: unmatchedWeights,
         };
       }
 

--- a/src/app/new.state/xml/xml.util.ts
+++ b/src/app/new.state/xml/xml.util.ts
@@ -125,37 +125,29 @@ export function changeWeightForSelectedVariables(
   Object.keys(frequencyTableForSelectedVariables).forEach((variableID) => {
     if (duplicateVariables[variableID]) {
       const currentCategories = duplicateVariables[variableID].catgry;
-      console.log('Weight ID: ', !!weightID);
       if (currentCategories && Array.isArray(currentCategories)) {
         currentCategories.map((category) => {
-          if (Array.isArray(category.catStat)) {
-            category.catStat = [
-              category.catStat[0],
-              {
-                '#text':
-                  weightID !== 'remove'
-                    ? frequencyTableForSelectedVariables[variableID][
-                        category.catValu
-                      ] || 0
-                    : 0,
-                '@_type': 'freq',
-                '@_wgtd': 'wgtd',
-                '@_wgt-var': weightID !== 'remove' ? weightID : '',
-              },
-            ];
+          const baseStat = Array.isArray(category.catStat)
+            ? category.catStat[0]
+            : category.catStat;
+          if (weightID === 'remove') {
+            const {
+              '@_wgtd': _wgtd,
+              '@_wgt-var': _wgtVar,
+              ...cleanStat
+            } = baseStat;
+            category.catStat = cleanStat;
           } else {
             category.catStat = [
-              category.catStat,
+              baseStat,
               {
                 '#text':
-                  weightID !== 'remove'
-                    ? frequencyTableForSelectedVariables[variableID][
-                        category.catValu
-                      ] || 0
-                    : 0,
+                  frequencyTableForSelectedVariables[variableID][
+                    category.catValu
+                  ] || 0,
                 '@_type': 'freq',
                 '@_wgtd': 'wgtd',
-                '@_wgt-var': weightID !== 'remove' ? weightID : '',
+                '@_wgt-var': weightID,
               },
             ];
           }

--- a/src/app/new.state/xml/xml.util.ts
+++ b/src/app/new.state/xml/xml.util.ts
@@ -1,6 +1,8 @@
 import {
   ImportVariableFormTemplate,
   MatchVariables,
+  SummaryStatistic,
+  UnmatchedWeightVariable,
   Variable,
   VariableGroup,
 } from './xml.interface';
@@ -445,8 +447,9 @@ export function createNewVariables(
   variablesMatched: MatchVariables,
   variables: Variable[],
   variableTemplate: ImportVariableFormTemplate,
-): Variable[] {
+): { variables: Variable[]; unmatchedWeights: UnmatchedWeightVariable[] } {
   const newVariables: Variable[] = [];
+  const unmatchedWeights: UnmatchedWeightVariable[] = [];
   const reverseLookup: {
     [importedVariableId: string]: {
       currentDatasetVariableID: string;
@@ -468,13 +471,14 @@ export function createNewVariables(
         variableTemplate,
         variablesMatched[variable['@_ID']],
         reverseLookup,
+        unmatchedWeights,
       );
       newVariables.push(updatedVariable);
     } else {
       newVariables.push(variable);
     }
   });
-  return newVariables;
+  return { variables: newVariables, unmatchedWeights };
 }
 
 function editSingleVariable(
@@ -490,6 +494,7 @@ function editSingleVariable(
       importedVariable: Variable;
     };
   },
+  unmatchedWeights: UnmatchedWeightVariable[],
 ): Variable {
   const currentVariableCloned = structuredClone(currentVariable);
   if (variableTemplate.label) {
@@ -525,18 +530,50 @@ function editSingleVariable(
     currentVariableCloned.notes = [systemNote, importedUserNote];
   }
   if (variableTemplate.weight) {
-    const importedVariable =
+    const importedWgtVar =
       importedVariablesMatched.importedVariable['@_wgt-var'];
-    currentVariableCloned['@_wgt-var'] = reverseLookup[importedVariable]
-      ? reverseLookup[importedVariable]?.currentDatasetVariableID
+    currentVariableCloned['@_wgt-var'] = reverseLookup[importedWgtVar]
+      ? reverseLookup[importedWgtVar].currentDatasetVariableID
       : '';
     currentVariableCloned['@_wgt'] = importedVariablesMatched.importedVariable[
       '@_wgt'
     ]
       ? importedVariablesMatched.importedVariable['@_wgt']
       : '';
-    currentVariableCloned.catgry =
-      importedVariablesMatched.importedVariable.catgry;
+
+    // Deep-copy catgry and remap any @_wgt-var references inside catStat
+    // from imported variable IDs to current-dataset variable IDs.
+    const importedCatgry = structuredClone(
+      importedVariablesMatched.importedVariable.catgry,
+    );
+    if (Array.isArray(importedCatgry)) {
+      importedCatgry.forEach((category) => {
+        const remapStat = (stat: SummaryStatistic): void => {
+          const wgtVar = stat['@_wgt-var'];
+          if (wgtVar === undefined) return;
+          if (reverseLookup[wgtVar]) {
+            stat['@_wgt-var'] = reverseLookup[wgtVar].currentDatasetVariableID;
+          } else {
+            // Imported weight reference has no match in the current dataset —
+            // strip weighted attributes so the stat is clean and Dataverse won't
+            // reject the XML for an unresolvable cross-reference.
+            unmatchedWeights.push({
+              variableID: currentVariable['@_ID'],
+              variableName: currentVariable['@_name'],
+              importedWgtVar: wgtVar,
+            });
+            delete stat['@_wgt-var'];
+            delete stat['@_wgtd'];
+          }
+        };
+        if (Array.isArray(category.catStat)) {
+          category.catStat.forEach(remapStat);
+        } else {
+          remapStat(category.catStat);
+        }
+      });
+    }
+    currentVariableCloned.catgry = importedCatgry;
   }
   const anyQuestionSelected =
     variableTemplate.literalQuestion ||


### PR DESCRIPTION
[ac25c67 — fix(weight): fix weight removal creating invalid catStat](https://github.com/scholarsportal/Dataverse-Data-Explorer/commit/ac25c675fbf58e37c5ac9de2fefe84c77325b64c)
When removing a weight assignment, the old code still wrote a second catStat entry marked wgtd="wgtd" with an empty wgt-var="". This is invalid DDI and could cause Dataverse to reject the upload. The fix restores catStat to a single clean unweighted entry, stripping @_wgtd and @_wgt-var entirely. Also removed a stale console.log.
[
ac25c67 → 9f38261 — fix(import): add unmatched weight variable handling in XML import](https://github.com/scholarsportal/Dataverse-Data-Explorer/commit/9f382613e578d33bfb029bb831522d51a7cf4698)
When importing weight metadata, catgry was copied verbatim from the imported dataset — including catStat entries whose @_wgt-var referenced variable IDs that don't exist in the current dataset. Dataverse validates these cross-references and rejects the upload. The fix walks every catStat entry after copying and remaps @_wgt-var through the existing reverseLookup. If a reference can't be mapped, both @_wgt-var and @_wgtd are stripped so the stat is left clean. Variables that lost their weight reference are collected into unmatchedImportedWeights and stored on state — with a TODO to surface this list to the user in the import component.
[
64835f7 — fix(import): handle missing variable groups in XML import processing](https://github.com/scholarsportal/Dataverse-Data-Explorer/commit/64835f770f61a69e4fa0285d839df6cdde0bf30c)
The groups import block used || [] as a fallback when the imported XML had no varGrp. This caused updateGroups([]) to return an empty array, silently wiping all existing groups in the current dataset. The fix checks for the presence of rawImportedGroups before calling updateGroups — if the imported XML has no groups, existing state groups are left untouched.